### PR TITLE
init: do not re-send the API key

### DIFF
--- a/custom_components/healthbox/__init__.py
+++ b/custom_components/healthbox/__init__.py
@@ -33,8 +33,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         api_key=api_key,
         session=async_get_clientsession(hass),
     )
-    if api_key:
-        await api.async_enable_advanced_api_features()
 
     coordinator = HealthboxDataUpdateCoordinator(hass=hass, entry=entry, api=api)
     await coordinator.async_config_entry_first_refresh()


### PR DESCRIPTION
First, thank you for this very nice integration!

This week, I installed your HA integration and it works really well! I have requested an API key to Renson's support and I can retrieve everything locally, that's great!

I then decided to block Internet access for my Healthbox 3.0. It continues to work as expected until this morning, after the HA upgrade to the latest version. The log were reporting an issue with the credentials (`Healthbox3ApiClientAuthenticationError`). The IP didn't change but I notice `v2/api/data/current` was reporting the key was `invalid`. I re-enabled Internet access, reloaded the integration and the error went away.

If I'm not mistaken, there is no need to re-send the API key at the init phase: this has already been done when validating the new configuration, no? (I didn't try)

Re-sending the API key will make the Healthbox sending a request to the cloud servers. If the Healthbox doesn't have Internet access at that time or if there is an issue with the remote servers, the integration will refuse to start. That's a shame because it doesn't depend on the Internet to work.

Maybe it would be good to call `_async_validate_advanced_api_features()` at the init phase if there is an API key set but then the user will need to be able to change the API key if there is an issue and as suggested in #30 :)