### PR TITLE
Add Fan sensors

### DIFF
--- a/custom_components/healthbox/manifest.json
+++ b/custom_components/healthbox/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/rmassch/healthbox-hacs/issues",
   "requirements": [
-    "pyhealthbox3==0.0.20"
+    "pyhealthbox3==0.0.21"
   ],
   "ssdp": [],
   "version": "0.0.1",

--- a/custom_components/healthbox/sensor.py
+++ b/custom_components/healthbox/sensor.py
@@ -14,6 +14,11 @@ from homeassistant.const import (
     UnitOfTemperature,
     PERCENTAGE,
     CONCENTRATION_PARTS_PER_MILLION,
+    ATTR_VOLTAGE,
+    REVOLUTIONS_PER_MINUTE,
+    UnitOfPower,
+    UnitOfPressure,
+    UnitOfVolumeFlowRate,
 )
 
 
@@ -238,6 +243,72 @@ def generate_global_sensors_for_healthbox(
                 value_fn=lambda x: x.wifi.ssid,
             )
         )
+
+    if coordinator.api.fan.voltage is not None:
+        global_sensors.append(
+            HealthboxGlobalSensorEntityDescription(
+                key="fan_voltage",
+                name="Fan Voltage",
+                icon="mdi:sine-wave",
+                native_unit_of_measurement=ATTR_VOLTAGE,
+                device_class=SensorDeviceClass.VOLTAGE,
+                state_class=SensorStateClass.MEASUREMENT,
+                value_fn=lambda x: x.fan.voltage,
+                suggested_display_precision=2,
+            )
+        )
+    if coordinator.api.fan.pressure is not None:
+        global_sensors.append(
+            HealthboxGlobalSensorEntityDescription(
+                key="fan_pressure",
+                name="Fan Pressure",
+                icon="mdi:arrow-collapse-vertical",
+                native_unit_of_measurement=UnitOfPressure.PA,
+                device_class=SensorDeviceClass.PRESSURE,
+                state_class=SensorStateClass.MEASUREMENT,
+                value_fn=lambda x: x.fan.pressure,
+                suggested_display_precision=2,
+            )
+        )
+    if coordinator.api.fan.flow is not None:
+        global_sensors.append(
+            HealthboxGlobalSensorEntityDescription(
+                key="fan_flow",
+                name="Fan Flow",
+                icon="mdi:wind-power",
+                native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
+                device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
+                state_class=SensorStateClass.MEASUREMENT,
+                value_fn=lambda x: x.fan.flow,
+                suggested_display_precision=2,
+            )
+        )
+    if coordinator.api.fan.power is not None:
+        global_sensors.append(
+            HealthboxGlobalSensorEntityDescription(
+                key="fan_power",
+                name="Fan Power",
+                icon="mdi:flash",
+                native_unit_of_measurement=UnitOfPower.WATT,
+                device_class=SensorDeviceClass.POWER,
+                state_class=SensorStateClass.MEASUREMENT,
+                value_fn=lambda x: x.fan.power,
+                suggested_display_precision=2,
+            )
+        )
+    if coordinator.api.fan.rpm is not None:
+        global_sensors.append(
+            HealthboxGlobalSensorEntityDescription(
+                key="fan_rpm",
+                name="Fan RPM",
+                icon="mdi:fan",
+                native_unit_of_measurement=REVOLUTIONS_PER_MINUTE,
+                device_class=SensorDeviceClass.SPEED,
+                state_class=SensorStateClass.MEASUREMENT,
+                value_fn=lambda x: x.fan.rpm,
+            )
+        )
+
     return global_sensors
 
 


### PR DESCRIPTION
If available.

Thanks to shocknl for the info.

Notes:
- I'm not sure about the icons
- About the units, I modified two of them compared to what shocknl put on the forum [1]: the flow in m³/h, and the pressure in Pa. That's the units used in the manual [2] and more aligned with the data I got:

```
  {
    "voltage": 2.3120000000000003,
    "pressure": 16.033831993094875,
    "flow": 97.989253893208,
    "power": 3.8216333353915815,
    "rpm": 420
  }
```

(Note: currently untested, but looks OK)

Depends-on: https://github.com/rmassch/pyhealthbox3/pull/1
Link: https://community.home-assistant.io/t/renson-healthbox-3-0/52983/120 [1]
Link: https://dam.renson.eu/Sites/A/Public_Publications/7258 [2]